### PR TITLE
Fix gosimple warning in exist tests

### DIFF
--- a/templates_test/exists.tpl
+++ b/templates_test/exists.tpl
@@ -23,7 +23,7 @@ func test{{$tableNamePlural}}Exists(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to check if {{$tableNameSingular}} exists: %s", err)
 	}
-	if e != true {
+	if !e {
 		t.Errorf("Expected {{$tableNameSingular}}ExistsG to return true, but got false.")
 	}
 }


### PR DESCRIPTION
fixes `should omit comparison to bool constant, can be simplified to !e (gosimple)`