### PR TITLE
use supplied conflictColumns in Upsert

### DIFF
--- a/templates/17_upsert.tpl
+++ b/templates/17_upsert.tpl
@@ -94,6 +94,8 @@ func (o *{{$tableNameSingular}}) Upsert(exec boil.Executor, {{if ne .DriverName 
 		if len(conflictColumns) == 0 {
 			conflict = make([]string, len({{$varNameSingular}}PrimaryKeyColumns))
 			copy(conflict, {{$varNameSingular}}PrimaryKeyColumns)
+		} else {
+			conflict = conflictColumns
 		}
 		cache.query = queries.BuildUpsertQueryPostgres(dialect, "{{$schemaTable}}", updateOnConflict, ret, update, conflict, whitelist)
 		{{- else -}}


### PR DESCRIPTION
using upsert today and found it generated an empty conflict target when given a non-empty `conflictColumns` argument. i'm not sure if there should be some additional work done on the passed in value before just sticking it in the query builder... but this is what i did to get it working for me now.