### PR TITLE
mysql driver: query only base tables

### DIFF
--- a/bdb/drivers/mysql.go
+++ b/bdb/drivers/mysql.go
@@ -81,7 +81,7 @@ func (m *MySQLDriver) UseLastInsertID() bool {
 func (m *MySQLDriver) TableNames(schema string, whitelist, blacklist []string) ([]string, error) {
 	var names []string
 
-	query := fmt.Sprintf(`select table_name from information_schema.tables where table_schema = ?`)
+	query := fmt.Sprintf(`select table_name from information_schema.tables where table_schema = ? and table_type = 'BASE TABLE'`)
 	args := []interface{}{schema}
 	if len(whitelist) > 0 {
 		query += fmt.Sprintf(" and table_name in (%s);", strings.Repeat(",?", len(whitelist))[1:])


### PR DESCRIPTION
hi @aarondl,

as long as it is not decided if views should be supported we have to ignore those when generating the model. Blacklisting would have worked, but I think this query fix is more appropriate.
