### PR TITLE
Add option to change output file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Flags:
       --basedir string          The base directory has the templates and templates_test folders
   -b, --blacklist stringSlice   Do not include these tables in your generated package
   -d, --debug                   Debug mode prints stack traces on error
+  -e, --extension string        The extension to use for output files (default ".go")
       --no-auto-timestamps      Disable automatic timestamps for created_at/updated_at
       --no-hooks                Disable hooks feature for your models
       --no-tests                Disable generated go test files

--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -47,6 +47,10 @@ type State struct {
 
 // New creates a new state based off of the config
 func New(config *Config) (*State, error) {
+	if config.FileExtension == "" {
+		config.FileExtension = ".go"
+	}
+
 	s := &State{
 		Config: config,
 	}

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	NoTests          bool
 	NoHooks          bool
 	NoAutoTimestamps bool
+	FileExtension    string
 
 	Postgres PostgresConfig
 	MySQL    MySQLConfig

--- a/boilingcore/output.go
+++ b/boilingcore/output.go
@@ -34,7 +34,7 @@ func generateOutput(state *State, data *templateData) error {
 		templates:            state.Templates,
 		importSet:            defaultTemplateImports,
 		combineImportsOnType: true,
-		fileSuffix:           ".go",
+		fileSuffix:           state.Config.FileExtension,
 	})
 }
 
@@ -46,7 +46,7 @@ func generateTestOutput(state *State, data *templateData) error {
 		templates:            state.TestTemplates,
 		importSet:            defaultTestTemplateImports,
 		combineImportsOnType: false,
-		fileSuffix:           "_test.go",
+		fileSuffix:           fmt.Sprintf("_test%s", state.Config.FileExtension),
 	})
 }
 
@@ -58,7 +58,7 @@ func generateSingletonOutput(state *State, data *templateData) error {
 		data:           data,
 		templates:      state.SingletonTemplates,
 		importNamedSet: defaultSingletonTemplateImports,
-		fileSuffix:     ".go",
+		fileSuffix:     state.Config.FileExtension,
 	})
 }
 
@@ -70,7 +70,7 @@ func generateSingletonTestOutput(state *State, data *templateData) error {
 		data:           data,
 		templates:      state.SingletonTestTemplates,
 		importNamedSet: defaultSingletonTestTemplateImports,
-		fileSuffix:     ".go",
+		fileSuffix:     state.Config.FileExtension,
 	})
 }
 
@@ -172,7 +172,7 @@ func generateTestMainOutput(state *State, data *templateData) error {
 		return err
 	}
 
-	if err := writeFile(state.Config.OutFolder, "main_test.go", out); err != nil {
+	if err := writeFile(state.Config.OutFolder, fmt.Sprintf("main_test%s", state.Config.FileExtension), out); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 	rootCmd.PersistentFlags().StringP("schema", "s", "public", "The name of your database schema, for databases that support real schemas")
 	rootCmd.PersistentFlags().StringP("pkgname", "p", "models", "The name you wish to assign to your generated package")
 	rootCmd.PersistentFlags().StringP("basedir", "", "", "The base directory has the templates and templates_test folders")
+	rootCmd.PersistentFlags().StringP("extension", "e", ".go", "The extension to use for output files")
 	rootCmd.PersistentFlags().StringSliceP("blacklist", "b", nil, "Do not include these tables in your generated package")
 	rootCmd.PersistentFlags().StringSliceP("whitelist", "w", nil, "Only include these tables in your generated package")
 	rootCmd.PersistentFlags().StringSliceP("tag", "t", nil, "Struct tags to be included on your models in addition to json, yaml, toml")
@@ -129,6 +130,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 		OutFolder:        viper.GetString("output"),
 		Schema:           viper.GetString("schema"),
 		PkgName:          viper.GetString("pkgname"),
+		FileExtension:    viper.GetString("extension"),
 		BaseDir:          viper.GetString("basedir"),
 		Debug:            viper.GetBool("debug"),
 		NoTests:          viper.GetBool("no-tests"),


### PR DESCRIPTION
Within a package, I like to clearly separate generated code from non-generated code. Being able to customize the file extension is an easy way to draw a line between the two.

For example, `users.gen.go` would contain the generated user model, then `users.go` could contain additional methods (`VerifyPassword`, for example).

This would also make it easier to target generated files in scripts (such as a CI script to flag changes to generated files).

I set the default extension to `.go` in order to maintain backwards compatibility.