### PR TITLE
[WIP] Driver plugin implementation

### DIFF
--- a/bdb/mysql/plugin.go
+++ b/bdb/mysql/plugin.go
@@ -1,0 +1,22 @@
+// +build plugin
+
+package main
+
+import (
+	"github.com/spf13/viper"
+	"github.com/vattle/sqlboiler/bdb"
+	"github.com/vattle/sqlboiler/bdb/drivers"
+)
+
+// InitDriver enables the default mysql driver to be used as a plugin. You could
+// also implement your own custom driver if you wanted.
+func InitDriver() (bdb.Interface, error) {
+	return drivers.NewMySQLDriver(
+		viper.GetString("mysql.user"),
+		viper.GetString("mysql.pass"),
+		viper.GetString("mysql.dbname"),
+		viper.GetString("mysql.host"),
+		viper.GetInt("mysql.port"),
+		viper.GetString("mysql.sslmode"),
+	), nil
+}

--- a/bdb/mysql/plugin.go
+++ b/bdb/mysql/plugin.go
@@ -3,20 +3,31 @@
 package main
 
 import (
-	"github.com/spf13/viper"
 	"github.com/vattle/sqlboiler/bdb"
 	"github.com/vattle/sqlboiler/bdb/drivers"
 )
+
+type configGetter interface {
+	GetString(string) string
+	GetInt(string) int
+}
+
+var config configGetter
+
+func SetConfig(c interface{}) error {
+	config = c.(configGetter)
+	return nil
+}
 
 // InitDriver enables the default mysql driver to be used as a plugin. You could
 // also implement your own custom driver if you wanted.
 func InitDriver() (bdb.Interface, error) {
 	return drivers.NewMySQLDriver(
-		viper.GetString("mysql.user"),
-		viper.GetString("mysql.pass"),
-		viper.GetString("mysql.dbname"),
-		viper.GetString("mysql.host"),
-		viper.GetInt("mysql.port"),
-		viper.GetString("mysql.sslmode"),
+		config.GetString("mysql.user"),
+		config.GetString("mysql.pass"),
+		config.GetString("mysql.dbname"),
+		config.GetString("mysql.host"),
+		config.GetInt("mysql.port"),
+		config.GetString("mysql.sslmode"),
 	), nil
 }

--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/vattle/sqlboiler/bdb"
-	"github.com/vattle/sqlboiler/bdb/drivers"
 	"github.com/vattle/sqlboiler/queries"
 	"github.com/vattle/sqlboiler/strmangle"
 )
@@ -256,44 +255,6 @@ func getBasePath(baseDirConfig string) (string, error) {
 	}
 
 	return os.Getwd()
-}
-
-// initDriver attempts to set the state Interface based off the passed in
-// driver flag value. If an invalid flag string is provided an error is returned.
-func (s *State) initDriver(driverName string) error {
-	// Create a driver based off driver flag
-	switch driverName {
-	case "postgres":
-		s.Driver = drivers.NewPostgresDriver(
-			s.Config.Postgres.User,
-			s.Config.Postgres.Pass,
-			s.Config.Postgres.DBName,
-			s.Config.Postgres.Host,
-			s.Config.Postgres.Port,
-			s.Config.Postgres.SSLMode,
-		)
-	case "mysql":
-		s.Driver = drivers.NewMySQLDriver(
-			s.Config.MySQL.User,
-			s.Config.MySQL.Pass,
-			s.Config.MySQL.DBName,
-			s.Config.MySQL.Host,
-			s.Config.MySQL.Port,
-			s.Config.MySQL.SSLMode,
-		)
-	case "mock":
-		s.Driver = &drivers.MockDriver{}
-	}
-
-	if s.Driver == nil {
-		return errors.New("An invalid driver name was provided")
-	}
-
-	s.Dialect.LQ = s.Driver.LeftQuote()
-	s.Dialect.RQ = s.Driver.RightQuote()
-	s.Dialect.IndexPlaceholders = s.Driver.IndexPlaceholders()
-
-	return nil
 }
 
 // initTables retrieves all "public" schema table names from the database.

--- a/boilingcore/boilingcore_no-plugins.go
+++ b/boilingcore/boilingcore_no-plugins.go
@@ -1,0 +1,46 @@
+// +build !linux !go1.8
+
+package boilingcore
+
+import (
+	"github.com/pkg/errors"
+	"github.com/vattle/sqlboiler/bdb/drivers"
+)
+
+// initDriver attempts to set the state Interface based off the passed in
+// driver flag value. If an invalid flag string is provided an error is returned.
+func (s *State) initDriver(driverName string) error {
+	// Create a driver based off driver flag
+	switch driverName {
+	case "postgres":
+		s.Driver = drivers.NewPostgresDriver(
+			s.Config.Postgres.User,
+			s.Config.Postgres.Pass,
+			s.Config.Postgres.DBName,
+			s.Config.Postgres.Host,
+			s.Config.Postgres.Port,
+			s.Config.Postgres.SSLMode,
+		)
+	case "mysql":
+		s.Driver = drivers.NewMySQLDriver(
+			s.Config.MySQL.User,
+			s.Config.MySQL.Pass,
+			s.Config.MySQL.DBName,
+			s.Config.MySQL.Host,
+			s.Config.MySQL.Port,
+			s.Config.MySQL.SSLMode,
+		)
+	case "mock":
+		s.Driver = &drivers.MockDriver{}
+	}
+
+	if s.Driver == nil {
+		return errors.New("An invalid driver name was provided")
+	}
+
+	s.Dialect.LQ = s.Driver.LeftQuote()
+	s.Dialect.RQ = s.Driver.RightQuote()
+	s.Dialect.IndexPlaceholders = s.Driver.IndexPlaceholders()
+
+	return nil
+}

--- a/boilingcore/boilingcore_plugins.go
+++ b/boilingcore/boilingcore_plugins.go
@@ -1,0 +1,71 @@
+// +build linux,go1.8
+
+package boilingcore
+
+import (
+	"plugin"
+
+	"github.com/pkg/errors"
+	"github.com/vattle/sqlboiler/bdb"
+	"github.com/vattle/sqlboiler/bdb/drivers"
+)
+
+// initDriver attempts to set the state Interface based off the passed in
+// driver flag value. If an invalid flag string is provided an error is returned.
+func (s *State) initDriver(driverName string) error {
+	// Create a driver based off driver flag
+	switch driverName {
+	case "postgres":
+		s.Driver = drivers.NewPostgresDriver(
+			s.Config.Postgres.User,
+			s.Config.Postgres.Pass,
+			s.Config.Postgres.DBName,
+			s.Config.Postgres.Host,
+			s.Config.Postgres.Port,
+			s.Config.Postgres.SSLMode,
+		)
+	case "mysql":
+		s.Driver = drivers.NewMySQLDriver(
+			s.Config.MySQL.User,
+			s.Config.MySQL.Pass,
+			s.Config.MySQL.DBName,
+			s.Config.MySQL.Host,
+			s.Config.MySQL.Port,
+			s.Config.MySQL.SSLMode,
+		)
+	case "mock":
+		s.Driver = &drivers.MockDriver{}
+	default:
+		driverPlugin, err := plugin.Open(driverName)
+		if err != nil {
+			return errors.Wrap(err, "unable to open plugin")
+		}
+
+		sym, err := driverPlugin.Lookup("InitDriver")
+		if err != nil {
+			return errors.Wrap(err, "could not find symbol InitDriver in plugin")
+		}
+
+		initializer, ok := sym.(func() (bdb.Interface, error))
+		if !ok {
+			return errors.New("symbol InitDriver is not `func() (bdb.Interface, error)`")
+		}
+
+		driver, err := initializer()
+		if err != nil {
+			return errors.Wrap(err, "failed to initialize driver")
+		}
+
+		s.Driver = driver
+	}
+
+	if s.Driver == nil {
+		return errors.New("An invalid driver name was provided")
+	}
+
+	s.Dialect.LQ = s.Driver.LeftQuote()
+	s.Dialect.RQ = s.Driver.RightQuote()
+	s.Dialect.IndexPlaceholders = s.Driver.IndexPlaceholders()
+
+	return nil
+}


### PR DESCRIPTION
Pursuant to discussion in #100, I put together an idea of what driver plugins might look like. As you can see, the implementation was fairly easy and didn't even require any breaking changes.

To use a plugin instead of a built-in driver, it's just `sqlboiler /path/to/plugin.so`.

A few items for consideration and/or discussion:

### Binary/plugin package versioning
The SQLBoiler binary and any plugins must be built with the exact same version of any packages imported by both.

I can see a few strategies that would help plugins to avoid these issues:
  - Plugins can vendor their dependencies.
    - This can potentially cause problems. If SQLBoiler imports the mysql driver, and a plugin imports its vendored mysql driver, the program will panic when the second driver is registered.
    - I haven't tested how well this would work with viper, it would probably be preferable for the plugin to use viper to define ifs own config directly instead of the injection strategy I used in e439620d6b1dcfca752cfd0b85f0d72744736d9c.

  - Plugins should avoid any dependencies on SQLBoiler packages that may change often.
    - The following changes would help with this:
      - Move `bdb.Interface` to a package containing only interfaces (and no code) needed by drivers (the `bdb/drivers` package could eventually become this).
      - Create interfaces for `bdb.Column`, `bdb.PrimaryKey`, and `bdb.ForeignKey`, and change `bdb.Interface` to return these instead of struct types.

  - In general, it would be a best practice for plugins to avoid external dependencies other than the necessary database driver(s).

### Managing plugins
Unless we add some tooling, there are going to be a couple of pain points with managing plugins. The current process for installing and using a driver plugin looks something like this:

```
go get github.com/vattle/sqlboiler-mysql
go build -buildmode=plugin -o /path/to/mysql-driver.so github.com/vattle/sqlboiler-mysql
sqlboiler /path/to/mysql-driver.so
```

To work around this, we could add sub-commands that would help with this process. By default, SQLBoiler could use a directory like `~/.sqlboiler-plugins` to store plugins.

- `sqlboiler get-plugin [-u] github.com/vattle/sqlboiler-mysql`
- `sqlboiler rebuild-plugin github.com/vattle/sqlboiler-mysql`

___

### Alternative Implementation

This is mainly a thought for the future -- I don't think it presents enough of a benefit right now.

We could accept a slice of plugin paths via config and load all of them. Each one would have an `init` function that registers a driver (similar to `database/sql.Register`).

#### Advantages
- Plugins could be something other than a driver (for example, a plugin to generate additional code)
  - An example might be something that adds methods to model slices (similar to the collection methods generated by http://clipperhouse.github.io/gen/)

#### Disadvantages
- This would make it harder for plugins to avoid depending on SQLBoiler directly, so they would probably have to be recompiled more often.
  - Again, this could be painstakingly worked around using interfaces and dependency injection, but 😕 

___

### Trying it out

If you want to try it out, it's pretty easy to do so. If you're on Linux (and using Go 1.8), skip to the last 3 steps.

```
docker run -v "$(pwd):/go/src/github.com/vattle/sqlboiler" -it golang:1.8 bash

cd /go/src/github.com/vattle/sqlboiler

go get ./...
go install .
go build -buildmode=plugin -o mysql.so ./bdb/mysql/plugin.go
sqlboiler mysql.so
```