### PR TITLE
Sort Table slice to ensure stable template output

### DIFF
--- a/bdb/interface.go
+++ b/bdb/interface.go
@@ -1,7 +1,11 @@
 // Package bdb supplies the sql(b)oiler (d)ata(b)ase abstractions.
 package bdb
 
-import "github.com/pkg/errors"
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+)
 
 // Interface for a database driver. Functionality required to support a specific
 // database type (eg, MySQL, Postgres etc.)
@@ -44,6 +48,8 @@ func Tables(db Interface, schema string, whitelist, blacklist []string) ([]Table
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get table names")
 	}
+
+	sort.Strings(names)
 
 	var tables []Table
 	for _, name := range names {

--- a/bdb/interface_test.go
+++ b/bdb/interface_test.go
@@ -124,6 +124,14 @@ func TestTables(t *testing.T) {
 		t.Errorf("Expected len 7, got: %d\n", len(tables))
 	}
 
+	prev := ""
+	for i := range tables {
+		if prev >= tables[i].Name {
+			t.Error("tables are not sorted")
+		}
+		prev = tables[i].Name
+	}
+
 	pilots := GetTable(tables, "pilots")
 	if len(pilots.Columns) != 2 {
 		t.Error()


### PR DESCRIPTION
Test templates range over `.Tables`, but because this slice is unsorted templates will render test cases in different orders after re-applying a migration.

This is a little annoying for users who track the rendered output in a VCS.

This little patch simply sorts the table names before creating the `[]bdb.Table` slice in `bdb.Tables()`. Test case included.
