### PR TITLE
Fix area plural issue, add testcase

### DIFF
--- a/strmangle/inflect.go
+++ b/strmangle/inflect.go
@@ -193,6 +193,7 @@ func newBoilRuleset() *inflect.Ruleset {
 	rs.AddSingularExact("is", "is", true)
 	rs.AddSingularExact("us", "us", true)
 	rs.AddSingularExact("as", "as", true)
+	rs.AddSingularExact("areas", "area", true)
 	rs.AddPluralExact("a", "a", true)
 	rs.AddPluralExact("i", "i", true)
 	rs.AddPluralExact("is", "is", true)

--- a/strmangle/strmangle_test.go
+++ b/strmangle/strmangle_test.go
@@ -139,6 +139,7 @@ func TestSingular(t *testing.T) {
 		{"hello_people", "hello_person"},
 		{"hello_person", "hello_person"},
 		{"friends", "friend"},
+		{"areas", "area"},
 		{"hello_there_people", "hello_there_person"},
 	}
 
@@ -159,6 +160,7 @@ func TestPlural(t *testing.T) {
 		{"hello_person", "hello_people"},
 		{"friend", "friends"},
 		{"friends", "friends"},
+		{"area", "areas"},
 		{"hello_there_person", "hello_there_people"},
 	}
 


### PR DESCRIPTION
- Fix #168 

Added specific case for the word `area` as discussed in #168 